### PR TITLE
AI Fix #148: Reference to non-existent attribute `variable.model`

### DIFF
--- a/micro_saas/models/docker_compose_template.py
+++ b/micro_saas/models/docker_compose_template.py
@@ -167,7 +167,7 @@ class DockerComposeTemplateVariable(models.Model):
             if not variable.field_name or self.user_has_groups('base.group_system'):
                 continue
 
-            model = self.env[variable.model]
+            model = self.env['odoo.docker.instance']
             if not model.check_access_rights('read', raise_exception=False):
                 raise ValidationError(_("You can not select field of %r.", variable.model))
 


### PR DESCRIPTION
Closes #148

Automatically applied AI code suggestion.

Please review carefully.